### PR TITLE
Add function to get Checkbox Options

### DIFF
--- a/src/pdfboxing/form.clj
+++ b/src/pdfboxing/form.clj
@@ -13,6 +13,16 @@
           form (.getAcroForm catalog)
           fields (.getFields form)]
       (into {} (map #(hash-map (.getPartialName %) (str (.getValue %))) fields)))))
+    
+(defn get-checkbox-field-options
+  "get the On and Off values for all Fields of type \"Btn\""
+  [pdfdoc]
+  (with-open [doc (PDDocument/load pdfdoc)]
+    (let [catalog (.getDocumentCatalog doc)
+          form (.getAcroForm catalog)
+          fields (.getFields form)
+          checkboxes (filter #(= "Btn" (.getFieldType %)) fields)]
+      (into {} (map #(hash-map (.getPartialName %) {:on (str (.getOnValue %)) :off (.getOffValue %)}) checkboxes)))))
 
 (defn set-fields
   "fill in the fields with the values provided"


### PR DESCRIPTION
I was having trouble setting the values for Checkboxes on a PDF form I am using. In my case the OnValue was "Yes" and the OffValue was "No". This function would have helped me save a bit of time.

While one could implement a .Check and .Uncheck version to set the values for CheckBoxes, I think that using the generic SetValue interop is better.