### PR TITLE
Fix for function name spelling

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ current names and the values new names:
 
 ```clojure
 (require '[pdfboxing.info :as info])
-(info/page-numbers "test/pdfs/interactiveform.pdf")
+(info/page-number "test/pdfs/interactiveform.pdf")
 ```
 ### Get info about a PDF document
 


### PR DESCRIPTION
Notified by @nukecoder of the misspelling of the function in the README as per #4 