### PR TITLE
Exposed the underlying error.

### DIFF
--- a/src/pdfboxing/form.clj
+++ b/src/pdfboxing/form.clj
@@ -27,7 +27,7 @@
             (.setValue (.getField form (name (key field))) (val field)))
           (.save doc output))
         (catch IOException e
-          (str "Error: can't add non-simple fonts, this is a constraint of PDFBox."))
+          (.getMessage e))
         (catch NullPointerException e
           (str "Error: non existent field provided"))))))
 


### PR DESCRIPTION
There isn't any reason to wrap this error. IOExceptions can happen
when the source or target destination don't exist. Surfacing an error
about non-simple fonts can be misleading.