### PR TITLE
Exposed the underlying error.

### DIFF
--- a/src/pdfboxing/form.clj
+++ b/src/pdfboxing/form.clj
@@ -26,8 +26,6 @@
           (doseq [field new-fields]
             (.setValue (.getField form (name (key field))) (val field)))
           (.save doc output))
-        (catch IOException e
-          (str "Error: can't add non-simple fonts, this is a constraint of PDFBox."))
         (catch NullPointerException e
           (str "Error: non existent field provided"))))))
 

--- a/test/pdfboxing/form_test.clj
+++ b/test/pdfboxing/form_test.clj
@@ -42,12 +42,12 @@
 
 (deftest populating-fields
   (testing "Error handling for non simple fonts"
-    (is (= "Error: can't add non-simple fonts, this is a constraint of PDFBox."
-           (set-fields "test/pdfs/interactiveform.pdf"
-                       "test/pdfs/filled-in.pdf"
-                       {"Name_Last" "Last",
-                        "Name_First" "First",
-                        "Name_Middle" "Middle"}))))
+    (is (thrown? java.io.IOException
+                 (set-fields "test/pdfs/interactiveform.pdf"
+                             "test/pdfs/filled-in.pdf"
+                             {"Name_Last" "Last",
+                              "Name_First" "First",
+                              "Name_Middle" "Middle"}))))
 
   (testing "Non existent field filling"
     (is (= "Error: non existent field provided"


### PR DESCRIPTION
There isn't any reason to wrap this error. IOExceptions can happen
when the source or target destination don't exist. Surfacing an error
about non-simple fonts can be misleading.