### PR TITLE
extract-from-pddocument defn: Moves .getText call in extract to separate defn

### DIFF
--- a/src/pdfboxing/text.clj
+++ b/src/pdfboxing/text.clj
@@ -2,9 +2,15 @@
   (:require [pdfboxing.common :as common])
   (:import [org.apache.pdfbox.util PDFTextStripper]))
 
+(defn extract-from-pddocument
+  "get text from a PDDocument"
+  [pddoc]
+    (if (instance? org.apache.pdfbox.pdmodel.PDDocument pddoc)
+      (let [stripper (new PDFTextStripper)]
+        (.getText stripper pddoc))))
+
 (defn extract
-  "get text from a PDF document"
+  "get text from a PDF document filesystem path"
   [pdfdoc]
   (with-open [doc (common/load-pdf pdfdoc)]
-    (let [stripper (new PDFTextStripper)]
-      (.getText stripper doc))))
+    (extract-from-pddocument doc)))

--- a/test/pdfboxing/text_test.clj
+++ b/test/pdfboxing/text_test.clj
@@ -1,6 +1,12 @@
 (ns pdfboxing.text-test
   (:require [clojure.test :refer :all]
-            [pdfboxing.text :refer :all]))
+            [pdfboxing.text :refer :all]
+            [pdfboxing.split :refer :all]))
+
+(deftest text-extraction-from-pddoc
+  (is (= "Hello, this is pdfboxing.text\n"
+         (extract-from-pddocument 
+           ((split-pdf :input "test/pdfs/hello.pdf") 0)))))
 
 (deftest text-extraction
   (is (= "Hello, this is pdfboxing.text\n"


### PR DESCRIPTION
Added so that you can extract text on page-by-page basis after `split-pdf`. More detailed explanation in commit.