### PR TITLE
is-pdf re-implementation

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -4,5 +4,4 @@
   :license {:name "BSD"
             :url "http://www.opensource.org/licenses/bsd-license.php"}
   :dependencies [[org.clojure/clojure "1.7.0"]
-                 [org.apache.pdfbox/pdfbox "1.8.10"]
-                 [org.apache.pdfbox/preflight "1.8.10"]])
+                 [org.apache.pdfbox/pdfbox "1.8.10"]])

--- a/src/pdfboxing/common.clj
+++ b/src/pdfboxing/common.clj
@@ -1,21 +1,17 @@
 (ns pdfboxing.common
+  (:require [pdfboxing.util :as util])
   (:import
    [javax.activation FileDataSource]
-   [org.apache.pdfbox.pdmodel PDDocument]
-   [org.apache.pdfbox.preflight.parser PreflightParser]))
-
+   [org.apache.pdfbox.pdmodel PDDocument]))
 
 (defn is-pdf?
-  "Confirm that the PDF supplied is really a PDF"
-  [pdf-file]
-  (let [data-source (FileDataSource. pdf-file)
-        parser (PreflightParser. data-source)]
-    (try
-      (do
-        (.parse parser)
-        true)
-      (catch Exception e false))))
-
+  "confirm if the given file name is a PDF file"
+    [string]
+    (let [content (line-seq (clojure.java.io/reader string))
+          first-line (first content)
+          second-line (second content)]
+      (and (util/first-line-valid? first-line)
+           (util/second-line-valid? second-line))))
 
 (defn load-pdf
   "Load a given PDF only after checking if it really is a PDF"

--- a/src/pdfboxing/util.clj
+++ b/src/pdfboxing/util.clj
@@ -27,3 +27,10 @@
     [second-line]
     (and (first-char-is-percent? (char (first (.getBytes second-line))))
          (valid-bytes? (rest second-line))))
+
+(defn second-line-valid?
+  "check if the second line of a PDF is valid"
+  [second-line]
+  (if (line-long-enough? second-line)
+    (valid-line-content? second-line)
+    false))

--- a/src/pdfboxing/util.clj
+++ b/src/pdfboxing/util.clj
@@ -4,3 +4,8 @@
   "validate the first line of a given PDF file"
     [first-line]
     (.matches first-line "%PDF-1\\.[1-9]"))
+
+(defn line-long-enough?
+  "check the length of the second line of a given PDF file"
+    [second-line]
+    (>= 5 (.length second-line)))

--- a/src/pdfboxing/util.clj
+++ b/src/pdfboxing/util.clj
@@ -14,3 +14,9 @@
   "check that the second line of a given PDF starts with a '%'"
   [first-char]
   (= "%" (str first-char)))
+
+(defn valid-bytes?
+  "check that the bytes on the second line of a given PDF are larger
+  than 127"
+  [given-bytes]
+  (not-any? false? (map #(< 0x80 (int %)) given-bytes)))

--- a/src/pdfboxing/util.clj
+++ b/src/pdfboxing/util.clj
@@ -10,7 +10,7 @@
 (defn line-long-enough?
   "check the length of the second line of a given PDF file"
     [second-line]
-    (>= 5 (.length second-line)))
+    (>= (.length second-line) 5))
 
 (defn first-char-is-percent?
   "check that the second line of a given PDF starts with a '%'"

--- a/src/pdfboxing/util.clj
+++ b/src/pdfboxing/util.clj
@@ -2,8 +2,10 @@
 
 (defn first-line-valid?
   "validate the first line of a given PDF file"
-    [first-line]
-    (.matches first-line "%PDF-1\\.[1-9]"))
+  [first-line]
+  (if (nil? first-line)
+    false
+    (.matches first-line "%PDF-1\\.[1-9]")))
 
 (defn line-long-enough?
   "check the length of the second line of a given PDF file"

--- a/src/pdfboxing/util.clj
+++ b/src/pdfboxing/util.clj
@@ -1,0 +1,6 @@
+(ns pdfboxing.util)
+
+(defn first-line-valid?
+  "validate the first line of a given PDF file"
+    [first-line]
+    (.matches first-line "%PDF-1\\.[1-9]"))

--- a/src/pdfboxing/util.clj
+++ b/src/pdfboxing/util.clj
@@ -20,3 +20,10 @@
   than 127"
   [given-bytes]
   (not-any? false? (map #(< 0x80 (int %)) given-bytes)))
+
+(defn valid-line-content?
+  "check if the line given is valid, to be used to verify the second
+  line of a PDF file"
+    [second-line]
+    (and (first-char-is-percent? (char (first (.getBytes second-line))))
+         (valid-bytes? (rest second-line))))

--- a/src/pdfboxing/util.clj
+++ b/src/pdfboxing/util.clj
@@ -9,3 +9,8 @@
   "check the length of the second line of a given PDF file"
     [second-line]
     (>= 5 (.length second-line)))
+
+(defn first-char-is-percent?
+  "check that the second line of a given PDF starts with a '%'"
+  [first-char]
+  (= "%" (str first-char)))

--- a/test/pdfboxing/util_test.clj
+++ b/test/pdfboxing/util_test.clj
@@ -11,3 +11,8 @@
   (testing "line length of the second line of a given PDF file"
     (is (false? (line-long-enough? "123456789")))
     (is (true? (line-long-enough? "12345")))))
+
+(deftest first-char-of-a-string
+  (testing "the start of the second line"
+    (is (false? (first-char-is-percent? (char \f))))
+    (is (true? (first-char-is-percent? (char \%))))))

--- a/test/pdfboxing/util_test.clj
+++ b/test/pdfboxing/util_test.clj
@@ -27,3 +27,8 @@
     (testing "if the line supplied is valid"
       (is (true? (valid-line-content? second-line)))
       (is (false? (valid-line-content? (clojure.string/replace second-line #"%" "!")))))))
+
+(deftest second-line-validation
+  (let [second-line (second (line-seq (clojure.java.io/reader "test/pdfs/clojure-1.pdf")))]
+    (testing "the second line of a PDF file"
+      (is (true? (second-line-valid? second-line))))))

--- a/test/pdfboxing/util_test.clj
+++ b/test/pdfboxing/util_test.clj
@@ -6,3 +6,8 @@
   (testing "the contents of the first line"
     (is (false? (first-line-valid? "%PDF-2")))
     (is (true? (first-line-valid? "%PDF-1.9")))))
+
+(deftest lenght-of-line
+  (testing "line length of the second line of a given PDF file"
+    (is (false? (line-long-enough? "123456789")))
+    (is (true? (line-long-enough? "12345")))))

--- a/test/pdfboxing/util_test.clj
+++ b/test/pdfboxing/util_test.clj
@@ -16,3 +16,8 @@
   (testing "the start of the second line"
     (is (false? (first-char-is-percent? (char \f))))
     (is (true? (first-char-is-percent? (char \%))))))
+
+(deftest bytes-validation
+  (testing "if passed in bytes are greater than 127"
+    (is (true? (valid-bytes? [0xff 0xe1 0xe9 0xeb 0xd3])))
+    (is (false? (valid-bytes? [0x11 0xe1 0xe9 0xeb 0xd3])))))

--- a/test/pdfboxing/util_test.clj
+++ b/test/pdfboxing/util_test.clj
@@ -1,0 +1,8 @@
+(ns pdfboxing.util-test
+  (:require [clojure.test :refer :all]
+            [pdfboxing.util :refer :all]))
+
+(deftest first-line-validation
+  (testing "the contents of the first line"
+    (is (false? (first-line-valid? "%PDF-2")))
+    (is (true? (first-line-valid? "%PDF-1.9")))))

--- a/test/pdfboxing/util_test.clj
+++ b/test/pdfboxing/util_test.clj
@@ -8,9 +8,9 @@
     (is (false? (first-line-valid? nil)))
     (is (true? (first-line-valid? "%PDF-1.9")))))
 
-(deftest lenght-of-line
+(deftest length-of-line
   (testing "line length of the second line of a given PDF file"
-    (is (false? (line-long-enough? "123456789")))
+    (is (false? (line-long-enough? "1234")))
     (is (true? (line-long-enough? "12345")))))
 
 (deftest first-char-of-a-string

--- a/test/pdfboxing/util_test.clj
+++ b/test/pdfboxing/util_test.clj
@@ -21,3 +21,9 @@
   (testing "if passed in bytes are greater than 127"
     (is (true? (valid-bytes? [0xff 0xe1 0xe9 0xeb 0xd3])))
     (is (false? (valid-bytes? [0x11 0xe1 0xe9 0xeb 0xd3])))))
+
+(deftest line-content-validation
+  (let [second-line (second (line-seq (clojure.java.io/reader "test/pdfs/clojure-1.pdf")))]
+    (testing "if the line supplied is valid"
+      (is (true? (valid-line-content? second-line)))
+      (is (false? (valid-line-content? (clojure.string/replace second-line #"%" "!")))))))

--- a/test/pdfboxing/util_test.clj
+++ b/test/pdfboxing/util_test.clj
@@ -5,6 +5,7 @@
 (deftest first-line-validation
   (testing "the contents of the first line"
     (is (false? (first-line-valid? "%PDF-2")))
+    (is (false? (first-line-valid? nil)))
     (is (true? (first-line-valid? "%PDF-1.9")))))
 
 (deftest lenght-of-line


### PR DESCRIPTION
The idea is to remove the external dependency on
`org.apache.pdfbox/preflight`.

The reason for that is since there is one less dependency, it's one less
thing to worry about when the project needs dependency updates.

And the check this dependency performed is something light so why not
have it on it's own.
