### PR TITLE
Release 0.1.9

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject pdfboxing "0.1.8"
+(defproject pdfboxing "0.1.9"
   :description "Clojure PDF manipulation library & wrapper for PDFBox"
   :url "https://github.com/dotemacs/pdfboxing"
   :license {:name "BSD"


### PR DESCRIPTION
After upgrading to PDFBox 2.0.0 and Clojure 1.8.0, bumping up the
release version to 0.1.9.