### PR TITLE
Support reading java.io.File objects by default

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,5 @@ pom.xml.asc
 .lein-failures
 .lein-plugins
 .lein-repl-history
+/bin/
+.classpath

--- a/src/pdfboxing/common.clj
+++ b/src/pdfboxing/common.clj
@@ -36,6 +36,11 @@
     (if (is-pdf? source)
       (load-pdf source)))
 
+  java.io.File
+  (obtain-document [source]
+    (if (is-pdf? source)
+      (load-pdf source)))
+
   org.apache.pdfbox.pdmodel.PDDocument
   (obtain-document [source]
     source))

--- a/test/pdfboxing/common_test.clj
+++ b/test/pdfboxing/common_test.clj
@@ -1,5 +1,6 @@
 (ns pdfboxing.common-test
   (:require [clojure.test :refer :all]
+            [clojure.java.io :as io]
             [pdfboxing.common :refer :all]))
 
 (deftest pdf-existance-check
@@ -18,3 +19,9 @@
     (is (true?  (instance?
                    org.apache.pdfbox.pdmodel.PDDocument
                    (obtain-document (obtain-document "test/pdfs/hello.pdf")))))))
+
+(deftest obtain-document-returns-pddocument-if-provided-file-check
+  (testing "obtain-document returns a PDDocument if a string path to a PDF is a supplied"
+    (is (true?  (instance?
+                   org.apache.pdfbox.pdmodel.PDDocument
+                   (obtain-document (io/file "test/pdfs/hello.pdf")))))))

--- a/test/pdfboxing/text_test.clj
+++ b/test/pdfboxing/text_test.clj
@@ -2,6 +2,8 @@
   (:require [clojure.test :refer :all]
             [pdfboxing.text :refer :all]))
 
+(def line-separator (System/getProperty "line.separator"))
+
 (deftest text-extraction
-  (is (= "Hello, this is pdfboxing.text\n"
+  (is (= (str "Hello, this is pdfboxing.text" line-separator)
          (extract "test/pdfs/hello.pdf"))))


### PR DESCRIPTION
I have a use case where I call pdfboxing.text/extract with a java.io.File argument. This broke when I upgraded to 0.1.9.

One test was broken on Windows, fixed that too.