### PR TITLE
Replace PreflightParser with PDFParser for JDK 9

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,3 +6,4 @@ jdk:
   - openjdk7
   - oraclejdk7
   - oraclejdk8
+  - oraclejdk9

--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ To list fields and values:
 
 ```clojure
 (require '[pdfboxing.form :as form])
-(form/get-fields "test/pdfs/interactiveform.pdf"))
+(form/get-fields "test/pdfs/interactiveform.pdf")
 {"Emergency_Phone" "", "ZIP" "", "COLLEGE NO DEGREE" "", ...}
 ```
 ### Fill in PDF forms

--- a/src/pdfboxing/common.clj
+++ b/src/pdfboxing/common.clj
@@ -2,17 +2,19 @@
   (:require [clojure.java.io :as io])
   (:import java.io.File
            org.apache.pdfbox.pdmodel.PDDocument
-           org.apache.pdfbox.preflight.parser.PreflightParser))
+           org.apache.pdfbox.io.RandomAccessFile
+           org.apache.pdfbox.pdfparser.PDFParser))
 
 (defn try-get-as-pdf
   "Try and get the pdf-file-or-path as a PDF.
   Returns nil if pdf-file-or-path could not be loaded as a PDF."
   [pdf-file-or-path]
   (let [^File pdf-file (io/as-file pdf-file-or-path)
-        parser (PreflightParser. pdf-file)]
+        random-access-file (RandomAccessFile. pdf-file "r")
+        parser (PDFParser. random-access-file)]
     (try
       (.parse parser)
-      (.getPreflightDocument parser)
+      (.getPDDocument parser)
       (catch Exception _))))
 
 (defn is-pdf?

--- a/src/pdfboxing/common.clj
+++ b/src/pdfboxing/common.clj
@@ -1,7 +1,6 @@
 (ns pdfboxing.common
   (:require [clojure.java.io :as io])
   (:import java.io.File
-           javax.activation.FileDataSource
            org.apache.pdfbox.pdmodel.PDDocument
            org.apache.pdfbox.preflight.parser.PreflightParser))
 
@@ -10,8 +9,7 @@
   Returns nil if pdf-file-or-path could not be loaded as a PDF."
   [pdf-file-or-path]
   (let [^File pdf-file (io/as-file pdf-file-or-path)
-        data-source (FileDataSource. pdf-file)
-        parser (PreflightParser. data-source)]
+        parser (PreflightParser. pdf-file)]
     (try
       (.parse parser)
       (.getPreflightDocument parser)


### PR DESCRIPTION
* PreflightParser uses imports javax namespace classes [here](https://github.com/apache/pdfbox/blob/4c78f2080fc1e7de03dfba2b8cb1a1dded07ac78/preflight/src/main/java/org/apache/pdfbox/preflight/parser/PreflightParser.java#L34) that are not available in JDK9. Hence I have used PDFParser for PDF.
* Added JDK9 to travis

This closes https://github.com/dotemacs/pdfboxing/issues/41