### PR TITLE
Add non-existing field name to form error message

### DIFF
--- a/src/pdfboxing/form.clj
+++ b/src/pdfboxing/form.clj
@@ -16,14 +16,13 @@
   [input output new-fields]
   (with-open [doc (common/obtain-document input)]
     (let [form (common/get-form doc)]
-      (try
-        (do
-          (doseq [field new-fields]
-            (-> (.getField form (name (key field)))
-                (.setValue (val field))))
-          (.save doc output))
-        (catch NullPointerException e
-          (str "Error: non existent field provided"))))))
+      (doseq [field new-fields]
+        (try
+          (-> (.getField form (name (key field)))
+              (.setValue (val field)))
+          (catch NullPointerException e
+            (throw (IllegalArgumentException. (str "Non-existing field " (key field) " provided")))))
+        (.save doc output)))))
 
 (defn rename-fields
   "take an input PDF, a new file to be created and a map with keys as

--- a/test/pdfboxing/form_test.clj
+++ b/test/pdfboxing/form_test.clj
@@ -10,13 +10,13 @@
     (io/delete-file file)))
 
 (deftest document-fields-and-value
-  (def document-fields-with-values {"last_name" "",
-                                    "first_name" "",
-                                    "date" "",
-                                    "checkbox1" "",
-                                    "checkbox2" "",
-                                    "checkbox3" "",
-                                    "checkbox4" "",
+  (def document-fields-with-values {"last_name" ""
+                                    "first_name" ""
+                                    "date" ""
+                                    "checkbox1" ""
+                                    "checkbox2" ""
+                                    "checkbox3" ""
+                                    "checkbox4" ""
                                     "checkbox5" ""})
   (is (= document-fields-with-values (get-fields "test/pdfs/interactiveform.pdf"))))
 
@@ -25,13 +25,13 @@
     (is (thrown? java.io.IOException
                  (set-fields "test/pdfs/old-interactiveform.pdf"
                              "test/pdfs/filled-in.pdf"
-                             {"Name_Last" "Last",
-                              "Name_First" "First",
+                             {"Name_Last" "Last"
+                              "Name_First" "First"
                               "Name_Middle" "Middle"}))))
 
   (testing "Non existent field filling"
-    (is (= "Error: non existent field provided"
-           (set-fields "test/pdfs/fillable.pdf" "test/pdfs/test.pdf" {"non-existent" "fail"}))))
+    (is (thrown? IllegalArgumentException
+                 (set-fields "test/pdfs/fillable.pdf" "test/pdfs/test.pdf" {"non-existent" "fail"}))))
 
   (testing "form filling valid fields"
     (is (nil? (set-fields "test/pdfs/interactiveform.pdf" "test/pdfs/test.pdf" {"first_name" "My first name"}))))


### PR DESCRIPTION
This is an improvement upon not so useful error message when you provide non-existing field into the `set-fields` function.