### PR TITLE
Update to pdfbox 2.0.12

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -4,4 +4,4 @@
   :license {:name "BSD"
             :url "http://www.opensource.org/licenses/bsd-license"}
   :dependencies [[org.clojure/clojure "1.9.0"]
-                 [org.apache.pdfbox/pdfbox "2.0.11"]])
+                 [org.apache.pdfbox/pdfbox "2.0.12"]])

--- a/test/pdfboxing/form_test.clj
+++ b/test/pdfboxing/form_test.clj
@@ -13,11 +13,11 @@
   (def document-fields-with-values {"last_name" ""
                                     "first_name" ""
                                     "date" ""
-                                    "checkbox1" ""
-                                    "checkbox2" ""
-                                    "checkbox3" ""
-                                    "checkbox4" ""
-                                    "checkbox5" ""})
+                                    "checkbox1" "Off"
+                                    "checkbox2" "Off"
+                                    "checkbox3" "Off"
+                                    "checkbox4" "Off"
+                                    "checkbox5" "Off"})
   (is (= document-fields-with-values (get-fields "test/pdfs/interactiveform.pdf"))))
 
 (deftest populating-fields


### PR DESCRIPTION
Seems to have broken a test w/r/t unchecked checkboxes. I updated the test assuming this was new behavior of the upstream library.

Closes #48.