### PR TITLE
Added byte array parsing to obtain-document function

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Added
 - Added the ability to merge multiple images into a single PDF
+- Added the ability to load PDFs from byte arrays
 
 ### Changed
 - Using lists for :imports

--- a/src/pdfboxing/common.clj
+++ b/src/pdfboxing/common.clj
@@ -39,6 +39,10 @@
   (obtain-document [source]))
 
 (extend-protocol PDFDocument
+  (class (byte-array 0))
+  (obtain-document [source]
+    (PDDocument/load source))
+
   String
   (obtain-document [source]
     (load-pdf source))

--- a/test/pdfboxing/common_test.clj
+++ b/test/pdfboxing/common_test.clj
@@ -2,9 +2,10 @@
   (:require [clojure.java.io :as io]
             [clojure.test :refer [deftest is testing]]
             [pdfboxing.common :refer [is-pdf? obtain-document]])
-  (:import org.apache.pdfbox.pdmodel.PDDocument))
+  (:import (org.apache.pdfbox.pdmodel PDDocument)
+           (java.nio.file Files)))
 
-(deftest pdf-existance-check
+(deftest pdf-existence-check
   (testing "If document supplied is a PDF"
     (is (false? (is-pdf? "test/pdfs/a.txt")))
     (is (true? (is-pdf? "test/pdfs/hello.pdf")))))
@@ -33,6 +34,16 @@
     (let [doc (obtain-document (io/file "test/pdfs/hello.pdf"))]
       (try
         (is (true? (instance? PDDocument doc)))
+        (finally
+          (when (instance? PDDocument doc)
+            (.close doc)))))))
+
+(deftest obtain-document-returns-pddocument-if-provided-byte-array-check
+  (testing "obtain-document returns a PDDocument if a byte-array of a pdf is supplied"
+    (let [bytes (Files/readAllBytes (.toPath (io/file "test/pdfs/hello.pdf")))
+          doc (obtain-document bytes)]
+      (try
+        (is (instance? PDDocument doc))
         (finally
           (when (instance? PDDocument doc)
             (.close doc)))))))


### PR DESCRIPTION
That way you can use other sources than the file system for loading pdfs.

## Description of your pull request

I needed the ability to load pdfs from other sources than files, in my case e-mails.

## Why should it be considered?

It's a small change and it adds a lot of useful functionality.

## Pull request checklist

Before submitting the PR make sure the following things have been done
(and denote this by checking the relevant checkboxes):

- [X] The code is consistent with [Clojure style guide](https://github.com/bbatsov/clojure-style-guide#the-clojure-style-guide).
- [X] All code passes the linter (`clj-kondo --lint src`).
- [X] You've added tests (if possible) to cover your change(s).
- [X] All tests are passing.
- [X] The commits are consistent with [the Git commit style guide](https://chris.beams.io/posts/git-commit/).
- [X] You've updated the [changelog](../blob/master/CHANGELOG.md) (if adding/changing user-visible functionality).


Thanks!
