### PR TITLE
Add functionality to extract PDF text from specific regions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## WIP
 
 ### Added
+- Added the ability to partially parse PDF content based on a vector of regions
 - Added the ability to merge multiple images into a single PDF
 - Added the ability to load PDFs from byte arrays
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,9 +3,9 @@
 ## WIP
 
 ### Added
-- Added the ability to partially parse PDF content based on a vector of regions
 - Added the ability to merge multiple images into a single PDF
 - Added the ability to load PDFs from byte arrays
+- Added the ability to partially parse PDF content based on a vector of regions
 
 ### Changed
 - Using lists for :imports

--- a/README.md
+++ b/README.md
@@ -18,6 +18,36 @@ Clojure PDF manipulation library & wrapper for [PDFBox](http://pdfbox.apache.org
 (text/extract "test/pdfs/hello.pdf")
 ```
 
+### Extract text from specific regions
+
+```clojure
+(require '[pdfboxing.text :as text])
+(let [areas [{:x           0
+              :y           100
+              :w           350
+              :h           50
+              :page-number 0}
+             {:x           0
+              :y           580
+              :w           540
+              :h           100
+              :page-number 0}]]
+  (text/extract-by-areas "test/pdfs/clojure-1.pdf" areas))
+```
+
+results in
+```clojure
+=> ("Clojure is a dynamic programming language\n" "Rationale\nFeatures\nDownload\nGetting Started\nDocumentation\nClojureScript\nClojureCLR\n")
+```
+
+Then you can easily turn the result into a map using zipmap to get the following:
+
+```clojure
+;; Result of (zipmap [:description :links] text-extract)
+
+{:description "Clojure is a dynamic programming language\n", :links "Rationale\nFeatures\nDownload\nGetting Started\nDocumentation\nClojureScript\nClojureCLR\n"}
+```
+
 ### Merge multiple PDFs
 
 ```clojure

--- a/src/pdfboxing/text.clj
+++ b/src/pdfboxing/text.clj
@@ -1,6 +1,8 @@
 (ns pdfboxing.text
   (:require [pdfboxing.common :as common])
-  (:import org.apache.pdfbox.text.PDFTextStripper))
+  (:import (org.apache.pdfbox.text PDFTextStripper
+                                   PDFTextStripperByArea)
+           (java.awt Rectangle)))
 
 (defn extract
   "get text from a PDF document"
@@ -8,3 +10,18 @@
   (with-open [doc (common/obtain-document pdfdoc)]
     (-> (PDFTextStripper.)
         (.getText doc))))
+
+(defn- area-text [doc {:keys [x y w h page-number] :as area}]
+  (let [page-number  (or page-number 0)
+        rectangle    (Rectangle. x y w h)
+        pdpage       (.getPage doc page-number)
+        textstripper (doto (PDFTextStripperByArea.)
+                       (.addRegion "region" rectangle)
+                       (.extractRegions pdpage))]
+    (.getTextForRegion textstripper "region")))
+
+(defn extract-by-areas
+  "get text from a specified area of a PDF document"
+  [pdfdoc areas]
+  (with-open [doc (common/obtain-document pdfdoc)]
+    (doall (map #(area-text doc %) areas))))

--- a/src/pdfboxing/text.clj
+++ b/src/pdfboxing/text.clj
@@ -11,7 +11,7 @@
     (-> (PDFTextStripper.)
         (.getText doc))))
 
-(defn- area-text [doc {:keys [x y w h page-number] :as area}]
+(defn- area-text [doc {:keys [x y w h page-number]}]
   (let [page-number  (or page-number 0)
         rectangle    (Rectangle. x y w h)
         pdpage       (.getPage doc page-number)

--- a/src/pdfboxing/text.clj
+++ b/src/pdfboxing/text.clj
@@ -21,7 +21,7 @@
     (.getTextForRegion textstripper "region")))
 
 (defn extract-by-areas
-  "get text from a specified area of a PDF document"
+  "get text from specified areas of a PDF document"
   [pdfdoc areas]
   (with-open [doc (common/obtain-document pdfdoc)]
     (doall (map #(area-text doc %) areas))))

--- a/src/pdfboxing/text.clj
+++ b/src/pdfboxing/text.clj
@@ -24,4 +24,4 @@
   "get text from specified areas of a PDF document"
   [pdfdoc areas]
   (with-open [doc (common/obtain-document pdfdoc)]
-    (doall (map #(area-text doc %) areas))))
+    (reduce (fn [v area] (conj v (area-text doc area))) [] areas)))

--- a/src/pdfboxing/text.clj
+++ b/src/pdfboxing/text.clj
@@ -11,9 +11,9 @@
     (-> (PDFTextStripper.)
         (.getText doc))))
 
-(defn- area-text [doc {:keys [x y w h page-number]}]
-  (let [page-number  (or page-number 0)
-        rectangle    (Rectangle. x y w h)
+(defn- area-text [doc {:keys [x y w h page-number]
+                       :or {x 0 y 0 w 0 h 0 page-number 0}}]
+  (let [rectangle    (Rectangle. x y w h)
         pdpage       (.getPage doc page-number)
         textstripper (doto (PDFTextStripperByArea.)
                        (.addRegion "region" rectangle)

--- a/test/pdfboxing/text_test.clj
+++ b/test/pdfboxing/text_test.clj
@@ -1,9 +1,24 @@
 (ns pdfboxing.text-test
   (:require [clojure.test :refer [deftest is]]
-            [pdfboxing.text :refer [extract]]))
+            [pdfboxing.text :refer [extract extract-by-areas]]))
 
 (def line-separator (System/getProperty "line.separator"))
 
 (deftest text-extraction
   (is (= (str "Hello, this is pdfboxing.text" line-separator)
          (extract "test/pdfs/hello.pdf"))))
+
+(deftest text-extract-by-areas
+  (let [areas [{:x           150
+                :y           100
+                :w           260
+                :h           40
+                :page-number 0}
+               {:x           380
+                :y           500
+                :w           27
+                :h           23
+                :page-number 4}]]
+    (is (= ["Clojure 1.6 Cheat Sheet (v21)\n"
+            "*ns*\n"]
+           (extract-by-areas "test/pdfs/multi-page.pdf" areas)))))

--- a/test/pdfboxing/text_test.clj
+++ b/test/pdfboxing/text_test.clj
@@ -1,5 +1,5 @@
 (ns pdfboxing.text-test
-  (:require [clojure.test :refer [deftest is]]
+  (:require [clojure.test :refer [deftest is testing]]
             [pdfboxing.text :refer [extract extract-by-areas]]))
 
 (def line-separator (System/getProperty "line.separator"))
@@ -21,4 +21,27 @@
                 :page-number 4}]]
     (is (= ["Clojure 1.6 Cheat Sheet (v21)\n"
             "*ns*\n"]
-           (extract-by-areas "test/pdfs/multi-page.pdf" areas)))))
+           (extract-by-areas "test/pdfs/multi-page.pdf" areas))))
+
+  (testing "default coordinate value is 0"
+    (let [areas [{:x           150
+                  :y           100
+                  :w           260
+                  :h           40}
+                 {:x           150
+                  :y           100
+                  :w           260
+                  :h           40
+                  :page-number 0}
+                 {:x           0
+                  :y           0
+                  :w           280
+                  :h           100
+                  :page-number 0}
+                 {:w           280
+                  :h           100}]]
+      (is (= ["Clojure 1.6 Cheat Sheet (v21)\n"
+              "Clojure 1.6 Cheat Sheet (v21)\n"
+              "5/23/2015\nClojure\n"
+              "5/23/2015\nClojure\n"]
+             (extract-by-areas "test/pdfs/multi-page.pdf" areas))))))


### PR DESCRIPTION
## Description of your pull request

(Feel free to squash & merge and use this as a commit message!)

Add functionality in `pdfboxing.text` to extract pdf text from specific regions

Large PDF documents can contain too much content to be properly parsed at once. It would often be preferable to locate the regions that contain the information and extract text from those instead, increasing parsing accuracy and retaining the semantics at the same time.

It's a rather small change that should not introduce a significant maintenance overhead.

Addresses #61 

## Pull request checklist

Before submitting the PR make sure the following things have been done
(and denote this by checking the relevant checkboxes):

- [X] The code is consistent with [Clojure style guide](https://github.com/bbatsov/clojure-style-guide#the-clojure-style-guide).
- [X] All code passes the linter (`clj-kondo --lint src`).
- [X] You've added tests (if possible) to cover your change(s).
- [X] All tests are passing.
- [X] The commits are consistent with [the Git commit style guide](https://chris.beams.io/posts/git-commit/).
- [X] You've updated the [changelog](../blob/master/CHANGELOG.md) (if adding/changing user-visible functionality).


Thanks!
