### PR TITLE
Save document only once on set-fields

### DIFF
--- a/src/pdfboxing/form.clj
+++ b/src/pdfboxing/form.clj
@@ -53,8 +53,8 @@
           (catch NullPointerException e
             (throw (IllegalArgumentException.
                     (str "Non-existing field " (key field)
-                         " provided, exception: " e)))))
-        (.save doc output)))))
+                         " provided, exception: " e))))))
+      (.save doc output))))
 
 (defn rename-fields
   "Take an `input` PDF, a string `output` as the new file to be created


### PR DESCRIPTION
## Description of your pull request

Change `set-fields` logic to save the document only once after all fields have been renamed. The current behavior calls `.save` after filling each field.

## Why should it be considered?

The main motivation for this is to support using the function `set-fields` with a `ByteArrayOutputStream`. 

The current logic calls `.save` after renaming each field, which appends the whole content of the PDF to the output stream, producing a bloated and potentially invalid PDF.

This is not a problem when passing a file since it just overwrites the file content each time, which works but seems inefficient.

## Why am I asking this?

In order to support using this function to save the result to a ByteArray.

## Pull request checklist

- [X] The code is consistent with [Clojure style guide](https://github.com/bbatsov/clojure-style-guide#the-clojure-style-guide).
- [X] All code passes the linter (`clj-kondo --lint src`).
- [X] You've added tests (if possible) to cover your change(s).
- [X] All tests are passing.
- [X] The commits are consistent with [the Git commit style guide](https://chris.beams.io/posts/git-commit/).
- [ ] You've updated the [changelog](../blob/master/CHANGELOG.md) (if adding/changing user-visible functionality).


Thanks for maintaining this lib!
