### PR TITLE
Fix for split-pdf

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Changed
 - Updated the CI jobs, by adding more JVMs to test against & added a clj-kondo lint job[#70](https://github.com/dotemacs/pdfboxing/pull/70)
+- `pdfboxing.split/split-pdf` wouldn't close a document when splitting[#73](https://github.com/dotemacs/pdfboxing/pull/73)
 
 ### Added
 - Added GitHub action based on antq, for outdated dependencies & updated outdated dependencies[#72](https://github.com/dotemacs/pdfboxing/pull/72)

--- a/src/pdfboxing/split.clj
+++ b/src/pdfboxing/split.clj
@@ -45,12 +45,12 @@
   "Split pdf into pages"
   [& {:keys [input start end split]}]
   {:pre [(arg-check input start end split)]}
-  (with-open [doc (common/obtain-document input)]
-    (let [splitter (Splitter.)]
-      (when start (.setStartPage splitter start))
-      (when end (.setEndPage splitter end))
-      (when split (.setSplitAtPage splitter split))
-      (into [] (.split splitter doc)))))
+  (let [doc (common/obtain-document input)
+        splitter (Splitter.)]
+    (when start (.setStartPage splitter start))
+    (when end (.setEndPage splitter end))
+    (when split (.setSplitAtPage splitter split))
+    (into [] (.split splitter doc))))
 
 (defn split-pdf-at
   "Splits a pdf into two documents and writes them to disk"


### PR DESCRIPTION
## Description of your pull request

Previously `with-open` was used to open the PDF document that would be split. Which is fine if you're just thinking about closing the file after you've split it. But it doesn't seem very useful, because once you've split the file, you probably want to do something with it.

I'm reverting this change introduced via
2ed58248360788cbdd4a4b5dbc95eadaddd9c767 just to get some opinions in this issue: https://github.com/dotemacs/pdfboxing/issues/46

## Pull request checklist

Before submitting the PR make sure the following things have been done
(and denote this by checking the relevant checkboxes):

- [x] The code is consistent with [Clojure style guide](https://github.com/bbatsov/clojure-style-guide#the-clojure-style-guide).
- [x] All code passes the linter (`clj-kondo --lint src`).
- [x] You've added tests (if possible) to cover your change(s).
- [x] All tests are passing.
- [x] The commits are consistent with [the Git commit style guide](https://chris.beams.io/posts/git-commit/).
- [x] You've updated the [changelog](../blob/master/CHANGELOG.md) (if adding/changing user-visible functionality).

