### PR TITLE
Updated dependencies to the latest stable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 - `pdfboxing.split/split-pdf` wouldn't close a document when splitting[#73](https://github.com/dotemacs/pdfboxing/pull/73)
 - Updated CI depdendency, GitHub action `actions/cache` to v3.3.1[#75](https://github.com/dotemacs/pdfboxing/pull/75)
 - Updated pdfbox & pdfbox-tools to the latest stable release[#76](https://github.com/dotemacs/pdfboxing/pull/76)
+- Updated pdfbox & pdfbox-tools to the latest stable release[#77](https://github.com/dotemacs/pdfboxing/pull/77)
 
 ### Added
 - Added GitHub action based on antq, for outdated dependencies & updated outdated dependencies[#72](https://github.com/dotemacs/pdfboxing/pull/72)

--- a/deps.edn
+++ b/deps.edn
@@ -1,6 +1,6 @@
 {:deps {org.clojure/clojure {:mvn/version "1.11.1"},
-        org.apache.pdfbox/pdfbox {:mvn/version "2.0.28"}
-        org.apache.pdfbox/pdfbox-tools {:mvn/version "2.0.28"}}
+        org.apache.pdfbox/pdfbox {:mvn/version "2.0.29"}
+        org.apache.pdfbox/pdfbox-tools {:mvn/version "2.0.29"}}
  :aliases {:test {:extra-paths ["test"]
                   :extra-deps {org.clojure/test.check {:mvn/version "RELEASE"}}}
            :runner {:extra-deps {com.cognitect/test-runner

--- a/project.clj
+++ b/project.clj
@@ -4,5 +4,5 @@
   :license {:name "BSD"
             :url "https://opensource.org/license/bsd-3-clause/"}
   :dependencies [[org.clojure/clojure "1.11.1"]
-                 [org.apache.pdfbox/pdfbox "2.0.28"]
-                 [org.apache.pdfbox/pdfbox-tools "2.0.28"]])
+                 [org.apache.pdfbox/pdfbox "2.0.29"]
+                 [org.apache.pdfbox/pdfbox-tools "2.0.29"]])


### PR DESCRIPTION
Updated pdfbox(-tools) to 2.0.29 as they were released yesterday and the automated CI job for depdendency checks is reporting outdated dependencies
